### PR TITLE
wip: pathwar compose down

### DIFF
--- a/go/pkg/pwcompose/config.go
+++ b/go/pkg/pwcompose/config.go
@@ -43,7 +43,8 @@ type dabservice struct {
 }
 
 type pathwarInfo struct {
-	RunningFlavors map[string]challengeFlavors
+	RunningFlavors   map[string]challengeFlavors
+	RunningInstances map[string]types.Container
 }
 
 type challengeFlavors struct {


### PR DESCRIPTION
Format is now on branch pwcompose_ps sorry for bad branch naming

Couldn't make work the args[0] to be parsed as []string

  ```
 composeDown := &ffcli.Command{
        Name:    "down",
        Usage:   "pathwar [global flags] compose [compose flags] down [flags] ID [ID...]",
        FlagSet: composeDownFlags,
        Exec: func(args []string) error {
            if err := globalPreRun(); err != nil {
                return err
            }
            if len(args) < 1 {
                return flag.ErrHelp
            }
            ids := args
            return pwcompose.Down(
                ids,
                *composeDownRemoveImages,
                *composeDownRemoveVolumes,
                logger)
        },
    }
```