### PR TITLE
fix: nginx_url computation was using user team member id on agent and…

### DIFF
--- a/go/pkg/pwagent/nginx.go
+++ b/go/pkg/pwagent/nginx.go
@@ -174,7 +174,7 @@ func genNginxConfig(apiInstances *pwapi.AgentListInstances_Output, containersInf
 		for _, seasonChallenge := range apiInstance.GetFlavor().GetSeasonChallenges() {
 			for _, subscription := range seasonChallenge.GetActiveSubscriptions() {
 				for _, member := range subscription.GetTeam().GetMembers() {
-					uniqueUsers[member.ID] = true
+					uniqueUsers[member.UserID] = true
 				}
 			}
 		}


### PR DESCRIPTION
… user id on api, made it use user id on both

<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->