### PR TITLE
fix: Check for browser on 404 to prevent page blink on gatsby build

### DIFF
--- a/web/src/pages/404.js
+++ b/web/src/pages/404.js
@@ -1,14 +1,18 @@
 import React from 'react';
 import { Link } from "gatsby";
 
+const browser = typeof window !== "undefined" && window;
+
 const NotFoundPage = () => {
   return (
-    <div>
-      <h4>
-        404 Page Not Found
-      </h4>
-      <Link to="/">Go back to homepage</Link>
-    </div>
+    browser && (
+      <div>
+        <h4>
+          404 Page Not Found
+        </h4>
+        <Link to="/">Go back to homepage</Link>
+      </div>
+    )
   );
 };
 


### PR DESCRIPTION
Test to check for window instance on 404, to prevent the error page blinking on gatsby production build.