### PR TITLE
fix: Page double loading to check auth

### DIFF
--- a/web/src/components/ProtectedRoute.js
+++ b/web/src/components/ProtectedRoute.js
@@ -9,11 +9,20 @@ import styles from "../styles/layout/loader.module.css";
 
 class ProtectedRoute extends React.PureComponent {
   componentDidMount() {
-    const { setKeycloakSession } = this.props;
+    const { setKeycloakSession, userSession } = this.props;
+    const { activeKeycloakSession } = userSession;
     const keycloak = new Keycloak("/keycloak.json");
+    const token = activeKeycloakSession && activeKeycloakSession.token;
+    const refreshToken =
+      activeKeycloakSession && activeKeycloakSession.refreshToken;
 
     keycloak
-      .init({ onLoad: "login-required", checkLoginIframe: false })
+      .init({
+        onLoad: "login-required",
+        checkLoginIframe: false,
+        token,
+        refreshToken,
+      })
       .then(authenticated => {
         setKeycloakSession(keycloak, authenticated);
       });


### PR DESCRIPTION
It seems to be keycloak related behavior on the first link they talk about that, to solve we're now passing the token and the refresh token stored in the state to the init when mounting a new page if they're available.

#525 

References to solve the problem:
http://keycloak-user.88327.x6.nabble.com/keycloak-user-Prevent-JS-Adapter-from-redirecting-if-already-logged-in-td1026.html

https://github.com/keycloak/keycloak-documentation/blob/master/securing_apps/topics/oidc/javascript-adapter.adoc#methods