### PR TITLE
fix: by default mariadb docker image uses utf8mb4 as encoding which i…

### DIFF
--- a/deployments/keycloak/docker-compose.yml
+++ b/deployments/keycloak/docker-compose.yml
@@ -39,6 +39,10 @@ services:
       - MYSQL_PASSWORD
     networks:
       - keycloak-internal
+    command:
+      - mysqld
+      - --character-set-server=utf8
+      - --collation-server=utf8_unicode_ci
 
 networks:
   keycloak-internal:


### PR DESCRIPTION
…s not compatible with keycloak

<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->