### PR TITLE
fix: training-http unique passphrase consistency

### DIFF
--- a/challenges/web/training-http/front/www/step2.php
+++ b/challenges/web/training-http/front/www/step2.php
@@ -1,4 +1,4 @@
-<?php header('X-Pathwar-Header: __PASSPHRASE3__'); ?>
+<?php header('X-Pathwar-Header: ValidationCodeWillBeGivenAtANextStep'); ?>
 <?php include("header.php"); ?>
 <div class="container-fluid">
     <div class="row">


### PR DESCRIPTION
The __PHASPHRASE3__ header looks like to be something forgotten by the "Fix to unique passphrase" commit #806184a2c3dc0329e23971cbe9bc0a184634e608

<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->