### PR TITLE
chore: Make dynamic app the root with ENV variable

### DIFF
--- a/web/.env.development
+++ b/web/.env.development
@@ -1,3 +1,4 @@
 API_URL=https://api-dev.pathwar.land/
 COMINGSOON=false
+APP_ROOT=false
 NODE_ENV=development

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,3 +1,4 @@
 API_URL=https://api.pathwar.land/
 COMINGSOON=true
+APP_ROOT=false
 NODE_ENV=production

--- a/web/gatsby-config.js
+++ b/web/gatsby-config.js
@@ -1,8 +1,12 @@
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`
+});
+
 module.exports = {
   siteMetadata: {
     title: `☠️ Pathwar Land ☠️ `,
     description: `Pathwar is an educational platform with a focus on security/cryptography, where you can go through challenges (courses) to learn new things and hone your skills.`,
-    baseUrl: `https://www.pathwar.land`,
+    baseUrl: `https://www.pathwar.land`
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
@@ -13,8 +17,8 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `${__dirname}/src/`,
-      },
+        path: `${__dirname}/src/`
+      }
     },
     {
       resolve: `gatsby-plugin-favicon`,
@@ -38,15 +42,15 @@ module.exports = {
           favicons: true,
           firefox: true,
           yandex: true,
-          windows: true,
-        },
-      },
+          windows: true
+        }
+      }
     },
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
-        trackingId: "UA-47629346-5",
-      },
-    },
-  ],
+        trackingId: "UA-47629346-5"
+      }
+    }
+  ]
 };

--- a/web/gatsby-config.js
+++ b/web/gatsby-config.js
@@ -1,12 +1,12 @@
 require("dotenv").config({
-  path: `.env.${process.env.NODE_ENV}`
+  path: `.env.${process.env.NODE_ENV}`,
 });
 
 module.exports = {
   siteMetadata: {
     title: `☠️ Pathwar Land ☠️ `,
     description: `Pathwar is an educational platform with a focus on security/cryptography, where you can go through challenges (courses) to learn new things and hone your skills.`,
-    baseUrl: `https://www.pathwar.land`
+    baseUrl: `https://www.pathwar.land`,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
@@ -17,8 +17,8 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `${__dirname}/src/`
-      }
+        path: `${__dirname}/src/`,
+      },
     },
     {
       resolve: `gatsby-plugin-favicon`,
@@ -42,15 +42,15 @@ module.exports = {
           favicons: true,
           firefox: true,
           yandex: true,
-          windows: true
-        }
-      }
+          windows: true,
+        },
+      },
     },
     {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
-        trackingId: "UA-47629346-5"
-      }
-    }
-  ]
+        trackingId: "UA-47629346-5",
+      },
+    },
+  ],
 };

--- a/web/gatsby-node.js
+++ b/web/gatsby-node.js
@@ -24,7 +24,7 @@ exports.onCreatePage = async ({ page, actions }) => {
 exports.onCreateWebpackConfig = ({ stage, actions }) => {
   if (stage === "develop") {
     actions.setWebpackConfig({
-      devtool: "eval-source-map"
+      devtool: "eval-source-map",
     });
   }
 };

--- a/web/gatsby-node.js
+++ b/web/gatsby-node.js
@@ -7,10 +7,14 @@
 exports.onCreatePage = async ({ page, actions }) => {
   const { createPage } = actions;
 
+  const appIsRoot = process.env.APP_ROOT === "true";
+  const matchingRegex = appIsRoot ? /^\/$/ : /^\/app/;
+  const matchingPath = appIsRoot ? `/*` : `/app/*`;
+
   // page.matchPath is a special key that's used for matching pages
   // only on the client.
-  if (page.path.match(/^\/app/)) {
-    page.matchPath = `/app/*`;
+  if (page.path.match(matchingRegex)) {
+    page.matchPath = matchingPath;
 
     // Update the page.
     createPage(page);
@@ -20,7 +24,7 @@ exports.onCreatePage = async ({ page, actions }) => {
 exports.onCreateWebpackConfig = ({ stage, actions }) => {
   if (stage === "develop") {
     actions.setWebpackConfig({
-      devtool: "eval-source-map",
+      devtool: "eval-source-map"
     });
   }
 };

--- a/web/src/components/SiteWrapper.js
+++ b/web/src/components/SiteWrapper.js
@@ -154,12 +154,23 @@ const langSwitcher = css`
   }
 `;
 
+const appPrefix = process.env.APP_ROOT === "true" ? "" : "/app";
+
 const listItems = [
-  { link: "/app/challenges", name: <FormattedMessage id="nav.challenges" /> },
-  { link: "/app/missions", name: <FormattedMessage id="nav.missions" /> },
-  { link: "/app/events", name: <FormattedMessage id="nav.events" /> },
-  { link: "/app/community", name: <FormattedMessage id="nav.community" /> },
-  { link: "/blog", name: <FormattedMessage id="nav.blog" /> },
+  {
+    link: `${appPrefix}/challenges`,
+    name: <FormattedMessage id="nav.challenges" />
+  },
+  {
+    link: `${appPrefix}/missions`,
+    name: <FormattedMessage id="nav.missions" />
+  },
+  { link: `${appPrefix}/events`, name: <FormattedMessage id="nav.events" /> },
+  {
+    link: `${appPrefix}/community`,
+    name: <FormattedMessage id="nav.community" />
+  },
+  { link: "/blog", name: <FormattedMessage id="nav.blog" /> }
 ];
 
 class SiteWrapper extends React.Component {
@@ -177,7 +188,7 @@ class SiteWrapper extends React.Component {
     const {
       cash,
       activeKeycloakSession,
-      activeUserSession: { claims } = {},
+      activeUserSession: { claims } = {}
     } = userSession;
 
     const username =
@@ -262,12 +273,12 @@ class SiteWrapper extends React.Component {
 SiteWrapper.propTypes = {
   children: PropTypes.node,
   userSession: PropTypes.object,
-  lastActiveTeam: PropTypes.object,
+  lastActiveTeam: PropTypes.object
 };
 
 const mapStateToProps = state => ({
   userSession: state.userSession,
-  activeSeason: state.seasons.activeSeason,
+  activeSeason: state.seasons.activeSeason
 });
 
 const mapDispatchToProps = {};

--- a/web/src/components/SiteWrapper.js
+++ b/web/src/components/SiteWrapper.js
@@ -159,18 +159,18 @@ const appPrefix = process.env.APP_ROOT === "true" ? "" : "/app";
 const listItems = [
   {
     link: `${appPrefix}/challenges`,
-    name: <FormattedMessage id="nav.challenges" />
+    name: <FormattedMessage id="nav.challenges" />,
   },
   {
     link: `${appPrefix}/missions`,
-    name: <FormattedMessage id="nav.missions" />
+    name: <FormattedMessage id="nav.missions" />,
   },
   { link: `${appPrefix}/events`, name: <FormattedMessage id="nav.events" /> },
   {
     link: `${appPrefix}/community`,
-    name: <FormattedMessage id="nav.community" />
+    name: <FormattedMessage id="nav.community" />,
   },
-  { link: "/blog", name: <FormattedMessage id="nav.blog" /> }
+  { link: "/blog", name: <FormattedMessage id="nav.blog" /> },
 ];
 
 class SiteWrapper extends React.Component {
@@ -188,7 +188,7 @@ class SiteWrapper extends React.Component {
     const {
       cash,
       activeKeycloakSession,
-      activeUserSession: { claims } = {}
+      activeUserSession: { claims } = {},
     } = userSession;
 
     const username =
@@ -273,12 +273,12 @@ class SiteWrapper extends React.Component {
 SiteWrapper.propTypes = {
   children: PropTypes.node,
   userSession: PropTypes.object,
-  lastActiveTeam: PropTypes.object
+  lastActiveTeam: PropTypes.object,
 };
 
 const mapStateToProps = state => ({
   userSession: state.userSession,
-  activeSeason: state.seasons.activeSeason
+  activeSeason: state.seasons.activeSeason,
 });
 
 const mapDispatchToProps = {};

--- a/web/src/pages/app.js
+++ b/web/src/pages/app.js
@@ -29,7 +29,7 @@ import "react-responsive-modal/styles.css";
 
 Sentry.init({
   dsn:
-    "https://8605d8e8fa21419d9a0e3f36a54df5cb@o406102.ingest.sentry.io/5272916"
+    "https://8605d8e8fa21419d9a0e3f36a54df5cb@o406102.ingest.sentry.io/5272916",
 });
 toast.configure();
 

--- a/web/src/pages/app.js
+++ b/web/src/pages/app.js
@@ -29,11 +29,14 @@ import "react-responsive-modal/styles.css";
 
 Sentry.init({
   dsn:
-    "https://8605d8e8fa21419d9a0e3f36a54df5cb@o406102.ingest.sentry.io/5272916",
+    "https://8605d8e8fa21419d9a0e3f36a54df5cb@o406102.ingest.sentry.io/5272916"
 });
 toast.configure();
 
-const App = () => {
+const appIsRoot = process.env.APP_ROOT === "true";
+const appPrefix = appIsRoot ? "" : "/app";
+
+export const App = () => {
   const currentTheme = useTheme();
   const { title, description } = siteMetaData;
 
@@ -88,20 +91,32 @@ const App = () => {
       <Location>
         {({ location }) => (
           <Router location={location}>
-            {/* <ProtectedRoute path="/app/home" component={HomePage} /> */}
-            <ProtectedRoute path="/app/challenges" component={ChallengesPage} />
-            <ProtectedRoute path="/app/statistics" component={StatisticsPage} />
             <ProtectedRoute
-              path="/app/team/:teamId"
+              path={`${appPrefix}/challenges`}
+              component={ChallengesPage}
+            />
+            <ProtectedRoute
+              path={`${appPrefix}/statistics`}
+              component={StatisticsPage}
+            />
+            <ProtectedRoute
+              path={`${appPrefix}/team/:teamId`}
               component={TeamDetailsPage}
             />
             <ProtectedRoute
-              path="/app/challenges/:challengeId"
+              path={`${appPrefix}/challenges/:challengeId`}
               component={ChallengeDetailsPage}
             />
-            <ProtectedRoute path="/app/settings" component={SettingsPage} />
-            <ProtectedRoute path="/app/logout" component={LogoutPage} />
+            <ProtectedRoute
+              path={`${appPrefix}/settings`}
+              component={SettingsPage}
+            />
+            <ProtectedRoute
+              path={`${appPrefix}/logout`}
+              component={LogoutPage}
+            />
             <ProtectedRoute path="/app" component={ChallengesPage} />
+            <ProtectedRoute path="/" component={ChallengesPage} />
           </Router>
         )}
       </Location>

--- a/web/src/pages/index.js
+++ b/web/src/pages/index.js
@@ -20,6 +20,7 @@ import footerLogoD from "../images/new-pathwar-logo-light-purple.svg";
 
 import islandLeadingBg from "../images/island-light-mode-illustration.svg";
 import islandLeadingBgDark from "../images/landing-island-darkmode-illustration.svg";
+import { App } from "./app";
 
 const logoWrapper = () => `
   width: fit-content;
@@ -183,6 +184,8 @@ const footer = ({ colors, type }) => `
     }
   }
 `;
+
+const appIsRoot = process.env.APP_ROOT === "true";
 
 const IndexPage = ({ data }) => {
   const currentTheme = useTheme();
@@ -397,7 +400,7 @@ export default ({ data }) => {
 
   return (
     <ThemeProvider theme={themeToUse}>
-      <IndexPage data={data} />
+      {appIsRoot ? <App /> : <IndexPage data={data} />}
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
## **What does this PR change?**
It creates an environment variable called **APP_ROOT** that can be set to true or false and make the dynamic application the main route of the app.

## **How to test?**
Change the **APP_ROOT** variable accordingly in the desired env (dev or prod), when accessing the app you should be in the dynamic app already, bypassing the homepage. Gatsby handles that with some node implementation.

Ref:
https://www.gatsbyjs.com/docs/reach-router-and-gatsby/#client-and-server-routing-
