### PR TITLE
fix: Wallet - adjust wallet to update after validation and purchase

### DIFF
--- a/web/src/state/userSessionReducer.js
+++ b/web/src/state/userSessionReducer.js
@@ -4,6 +4,8 @@ import {
   SET_USER_SESSION,
   SET_KEYCLOAK_SESSION,
   VALIDATE_COUPON_SUCCESS,
+  VALIDATE_CHALLENGE_SUCCESS,
+  BUY_CHALLENGE_SUCCESS,
 } from "../constants/actionTypes";
 
 const initialState = {
@@ -63,6 +65,18 @@ export default function userSessionReducer(
       return {
         ...state,
         cash: action.payload.team.cash,
+      };
+
+    case VALIDATE_CHALLENGE_SUCCESS:
+      return {
+        ...state,
+        cash: action.payload.challengeSubscription.team.cash,
+      };
+
+    case BUY_CHALLENGE_SUCCESS:
+      return {
+        ...state,
+        cash: action.payload.challengeSubscription.team.cash,
       };
 
     default:


### PR DESCRIPTION
## What this PR is changing?

It adjusts the wallet to update values after validation and purchase, now the user reducer is listening to the relative actions and updating the correct piece of the reducer with team cash data.

![Mar-25-2022 2-29-02 PM](https://user-images.githubusercontent.com/6627610/160171756-9d35c433-a35d-4c64-9b5b-36a38f37f085.gif)