### PR TITLE
fix: Stats page

### DIFF
--- a/web/src/components/SiteWrapper.js
+++ b/web/src/components/SiteWrapper.js
@@ -159,10 +159,10 @@ const listItems = [
     link: `/challenges`,
     name: <FormattedMessage id="nav.challenges" />,
   },
-  // {
-  //   link: `${appPrefix}/missions`,
-  //   name: <FormattedMessage id="nav.missions" />,
-  // },
+  {
+    link: `/statistics`,
+    name: <FormattedMessage id="nav.statistics" />,
+  },
   // { link: `${appPrefix}/events`, name: <FormattedMessage id="nav.events" /> },
   // {
   //   link: `${appPrefix}/community`,

--- a/web/src/components/season/AllTeamsOnSeasonList.js
+++ b/web/src/components/season/AllTeamsOnSeasonList.js
@@ -1,27 +1,50 @@
-import * as React from "react";
+import React, { useMemo } from "react";
 // import { Link } from "@reach/router";
-import { Card, Table, Dimmer } from "tabler-react";
+import { Card, Table, Dimmer, Avatar } from "tabler-react";
 import PropTypes from "prop-types";
-import moment from "moment";
+import { css } from "@emotion/core";
+import * as R from "ramda";
 
 // import styles from "./style.module.css";
 import { FormattedMessage } from "react-intl";
 
 const TeamsRows = ({ teams }) => {
-  return teams.map(item => {
+  const scoreCashSort = R.sortWith([
+    R.descend(R.prop("score")),
+    R.descend(R.prop("cash")),
+  ]);
+
+  const sortedTeamsByScoreAndCash = useMemo(() => scoreCashSort(teams), [
+    scoreCashSort,
+    teams,
+  ]);
+
+  return sortedTeamsByScoreAndCash.map((item, idx) => {
     return (
       <Table.Row key={item.organization.id}>
-        <Table.Col>{item.organization.name}</Table.Col>
+        <Table.Col alignContent="center">{idx + 1}</Table.Col>
+
+        <Table.Col
+          css={css`
+            display: flex;
+            align-items: center;
+          `}
+        >
+          <Avatar
+            className="mr-2"
+            imageURL={`${item.organization.gravatar_url}?d=identicon`}
+          />
+          <span>{item.organization.name}</span>
+        </Table.Col>
+        <Table.Col alignContent="center">{item.score}</Table.Col>
+        {/* <Table.Col colSpan={1} alignContent="center">
+          {item.nb_achievements}
+        </Table.Col> */}
         <Table.Col alignContent="center">
           {(item.cash && `$${item.cash}`) || "$0"}
         </Table.Col>
-        <Table.Col alignContent="center">
-          {moment(item.created_at).calendar()}
-        </Table.Col>
-        {/* <Table.Col colSpan={1} alignContent="center">
-          {item.score}
-        </Table.Col>
-        <Table.Col colSpan={1} alignContent="center">
+
+        {/*<Table.Col colSpan={1} alignContent="center">
           {item.gold_medals || 0}
         </Table.Col>
         <Table.Col colSpan={1} alignContent="center">
@@ -51,19 +74,22 @@ const AllTeamsOnSeasonList = ({ activeSeason, allTeamsOnSeason }) => {
       >
         <Table.Header>
           <Table.Row>
+            <Table.ColHeader alignContent="center">
+              <FormattedMessage id="AllTeamsOnSeasonList.rank" />
+            </Table.ColHeader>
             <Table.ColHeader>
               <FormattedMessage id="AllTeamsOnSeasonList.team" />
             </Table.ColHeader>
             <Table.ColHeader alignContent="center">
-              <FormattedMessage id="AllTeamsOnSeasonList.cash" />
-            </Table.ColHeader>
-            <Table.ColHeader alignContent="center">
-              <FormattedMessage id="AllTeamsOnSeasonList.joined" />
+              <FormattedMessage id="AllTeamsOnSeasonList.score" />
             </Table.ColHeader>
             {/* <Table.ColHeader colSpan={1} alignContent="center">
-              Score
+              <FormattedMessage id="AllTeamsOnSeasonList.achievements" />
+            </Table.ColHeader> */}
+            <Table.ColHeader alignContent="center">
+              <FormattedMessage id="AllTeamsOnSeasonList.cash" />
             </Table.ColHeader>
-            <Table.ColHeader colSpan={1}>
+            {/* <Table.ColHeader colSpan={1}>
               <Icon name="award" className={styles.goldMedal} />
             </Table.ColHeader>
             <Table.ColHeader colSpan={1} alignContent="center">

--- a/web/src/components/season/AllTeamsOnSeasonList.js
+++ b/web/src/components/season/AllTeamsOnSeasonList.js
@@ -20,31 +20,32 @@ const TeamsRows = ({ teams }) => {
   ]);
 
   return sortedTeamsByScoreAndCash.map((item, idx) => {
-    return (
-      <Table.Row key={item.organization.id}>
-        <Table.Col alignContent="center">{idx + 1}</Table.Col>
+    if (item.score && item.cash) {
+      return (
+        <Table.Row key={item.organization.id}>
+          <Table.Col alignContent="center">{idx + 1}</Table.Col>
 
-        <Table.Col
-          css={css`
-            display: flex;
-            align-items: center;
-          `}
-        >
-          <Avatar
-            className="mr-2"
-            imageURL={`${item.organization.gravatar_url}?d=identicon`}
-          />
-          <span>{item.organization.name}</span>
-        </Table.Col>
-        <Table.Col alignContent="center">{item.score}</Table.Col>
-        {/* <Table.Col colSpan={1} alignContent="center">
+          <Table.Col
+            css={css`
+              display: flex;
+              align-items: center;
+            `}
+          >
+            <Avatar
+              className="mr-2"
+              imageURL={`${item.organization.gravatar_url}?d=identicon`}
+            />
+            <span>{item.organization.name}</span>
+          </Table.Col>
+          <Table.Col alignContent="center">{item.score}</Table.Col>
+          {/* <Table.Col colSpan={1} alignContent="center">
           {item.nb_achievements}
         </Table.Col> */}
-        <Table.Col alignContent="center">
-          {(item.cash && `$${item.cash}`) || "$0"}
-        </Table.Col>
+          <Table.Col alignContent="center">
+            {(item.cash && `$${item.cash}`) || "$0"}
+          </Table.Col>
 
-        {/*<Table.Col colSpan={1} alignContent="center">
+          {/*<Table.Col colSpan={1} alignContent="center">
           {item.gold_medals || 0}
         </Table.Col>
         <Table.Col colSpan={1} alignContent="center">
@@ -56,8 +57,9 @@ const TeamsRows = ({ teams }) => {
         <Table.Col colSpan={1} alignContent="center">
           {item.nb_achievements || 0}
         </Table.Col> */}
-      </Table.Row>
-    );
+        </Table.Row>
+      );
+    }
   });
 };
 

--- a/web/src/pages/StatisticsPage.js
+++ b/web/src/pages/StatisticsPage.js
@@ -5,21 +5,21 @@ import { Grid, Page } from "tabler-react";
 import { useIntl } from "react-intl";
 import siteMetaData from "../constants/metadata";
 import AllTeamsOnSeasonList from "../components/season/AllTeamsOnSeasonList";
-import CreateTeamButton from "../components/team/CreateTeamButton";
+// import CreateTeamButton from "../components/team/CreateTeamButton";
 import {
   fetchAllSeasonTeams as fetchAllSeasonTeamsAction,
-  createTeam as createTeamAction,
+  // createTeam as createTeamAction,
 } from "../actions/seasons";
 
 const StatisticsPage = () => {
   const intl = useIntl();
   const dispatch = useDispatch();
   const activeSeason = useSelector(state => state.seasons.activeSeason);
-  const activeTeamInSeason = useSelector(
-    state => state.seasons.activeTeamInSeason
-  );
+  // const activeTeamInSeason = useSelector(
+  //   state => state.seasons.activeTeamInSeason
+  // );
   const allTeamsOnSeason = useSelector(state => state.seasons.allTeamsOnSeason);
-  const dispatchCreateTeamAction = dispatch(createTeamAction);
+  // const dispatchCreateTeamAction = dispatch(createTeamAction);
 
   useEffect(() => {
     if (!allTeamsOnSeason && activeSeason) {
@@ -40,14 +40,14 @@ const StatisticsPage = () => {
       </Helmet>
       <Page.Content title={statisticsIntl}>
         <Grid.Row cards={true}>
-          <Grid.Col xs={12} sm={12} md={3}>
+          {/* <Grid.Col xs={12} sm={12} md={3}>
             <CreateTeamButton
               activeSeason={activeSeason}
               createTeam={dispatchCreateTeamAction}
               activeTeamInSeason={activeTeamInSeason}
             />
-          </Grid.Col>
-          <Grid.Col xs={12} sm={12} md={9}>
+          </Grid.Col> */}
+          <Grid.Col xs={12} sm={12} md={12}>
             <AllTeamsOnSeasonList
               activeSeason={activeSeason}
               allTeamsOnSeason={allTeamsOnSeason}

--- a/web/src/translations/en.json
+++ b/web/src/translations/en.json
@@ -4,7 +4,7 @@
   "nav.events": "Events",
   "nav.community": "Community",
   "nav.blog": "Blog",
-  "nav.statistics": "Statistics",
+  "nav.statistics": "Stats",
   "userNav.profile": "Profile",
   "userNav.messages": "Messages",
   "userNav.wallet": "Wallet",
@@ -53,5 +53,8 @@
   "AllTeamsOnSeasonList.team": "Team",
   "AllTeamsOnSeasonList.cash": "Cash",
   "AllTeamsOnSeasonList.joined": "Joined",
+  "AllTeamsOnSeasonList.rank": "Rank",
+  "AllTeamsOnSeasonList.score": "Score",
+  "AllTeamsOnSeasonList.achievements": "Achievements",
   "CreateTeamButton.send": "Send"
 }


### PR DESCRIPTION
## What does this PR changes?

This PR is enabling the stats menu entry again and it's changing the stats list to display the user avatar and the score. Also, some items that are not ready to use info are hidden by now. 

Known issues:
- Sorting needs to be revisited, it's not 100%
- The implementation to display inactive in the list using a URL param will come on another PR  

![image](https://user-images.githubusercontent.com/6627610/161144730-37379c47-e6b1-4e7c-bde2-86ed2a1ab1f7.png)
