### PR TITLE
fix: UI fixes - home challenges, fake info and +

### DIFF
--- a/web/src/components/home/UserChallengesView.js
+++ b/web/src/components/home/UserChallengesView.js
@@ -55,7 +55,7 @@ const UserChallengesView = ({ challenges }) => {
             {purchasedNotSolved && purchasedNotSolved.length ? (
               <Grid.Row>
                 {purchasedNotSolved.map(challenge => (
-                  <Grid.Col lg={4} sm={12} xs={12} key={challenge.id}>
+                  <Grid.Col xl={4} lg={6} sm={12} xs={12} key={challenge.id}>
                     <ChallengeCard challenge={challenge} columnMode={true} />
                   </Grid.Col>
                 ))}

--- a/web/src/pages/ChallengeDetailsPage.js
+++ b/web/src/pages/ChallengeDetailsPage.js
@@ -79,11 +79,11 @@ const ChallengeDetailsPage = props => {
       >
         <Grid.Row className="mb-3">
           {challenge && (
-            <Grid.Col sm={12} md={7}>
+            <Grid.Col sm={12}>
               <ChallengeCard challenge={challenge} withModal={false} />
             </Grid.Col>
           )}
-          <Grid.Col sm={12} md={5}>
+          <Grid.Col sm={12}>
             <ShadowBox>
               <h3>
                 <FormattedMessage id="ChallengeDetailsPage.solve" />
@@ -94,13 +94,13 @@ const ChallengeDetailsPage = props => {
               />
               {purchased && !validations && (
                 <Tag css={statusTag}>
-                  <FormattedMessage id="ChallengeDetailsPage.purchased" />
+                  <FormattedMessage id="ChallengeDetailsPage.purchased" />{" "}
                   {moment(subscription.created_at).calendar()}
                 </Tag>
               )}
               {purchased && validations && (
                 <Tag color={validationStatusColor}>
-                  <FormattedMessage id="ChallengeDetailsPage.validated" />
+                  <FormattedMessage id="ChallengeDetailsPage.validated" />{" "}
                   {moment(validation.created_at).calendar()}
                 </Tag>
               )}

--- a/web/src/pages/HomePage.js
+++ b/web/src/pages/HomePage.js
@@ -113,7 +113,7 @@ const HomePage = () => {
               </h2>
               {teamDetails && (
                 <div css={{ display: "flex", justifyContent: "space-around" }}>
-                  <ProgressCard
+                  {/* <ProgressCard
                     css={cardStyle}
                     content={`# ${rank || "-"}`}
                     header={intl.formatMessage({ id: "HomePage.rank" })}
@@ -122,7 +122,7 @@ const HomePage = () => {
                     css={cardStyle}
                     content={teamDetails.score ? teamDetails.score : 0}
                     header={intl.formatMessage({ id: "HomePage.score" })}
-                  />
+                  /> */}
                   <ProgressCard
                     css={cardStyle}
                     content={`$${teamDetails.cash ? teamDetails.cash : 0}`}


### PR DESCRIPTION
## What does this PR changes?

- It adjusts the home challenges grid for smaller/medium screens
- Hide score and rank, they are fake info by now
- Adjust internal challenge visualization to use multiple lines
- Add spacing to "purchased" and "validated" tags inside challenges