### PR TITLE
feat: save score in DB

### DIFF
--- a/go/cmd/pathwar/compose.go
+++ b/go/cmd/pathwar/compose.go
@@ -20,7 +20,7 @@ import (
 )
 
 func composeCommand() *ffcli.Command {
-	var composeFlags = flag.NewFlagSet("compose", flag.ExitOnError)
+	composeFlags := flag.NewFlagSet("compose", flag.ExitOnError)
 	return &ffcli.Command{
 		Name:       "compose",
 		ShortUsage: "pathwar [global flags] compose [compose flags] <subcommand> [flags] [args...]",
@@ -126,7 +126,7 @@ func composePrepareCommand() *ffcli.Command {
 }
 
 func composePsCommand() *ffcli.Command {
-	var composePSFlags = flag.NewFlagSet("compose ps", flag.ExitOnError)
+	composePSFlags := flag.NewFlagSet("compose ps", flag.ExitOnError)
 	composePSFlags.IntVar(&composePSDepth, "depth", 0, "depth to display")
 	return &ffcli.Command{
 		Name:       "ps",
@@ -180,9 +180,7 @@ func composeDownCommand() *ffcli.Command {
 }
 
 func composeBinCommand() *ffcli.Command {
-	var (
-		composeBinFlags = flag.NewFlagSet("compose bin", flag.ExitOnError)
-	)
+	composeBinFlags := flag.NewFlagSet("compose bin", flag.ExitOnError)
 	return &ffcli.Command{
 		Name:       "bin",
 		ShortUsage: "pathwar [global flags] compose [compose flags] bin",

--- a/go/cmd/pathwar/main_test.go
+++ b/go/cmd/pathwar/main_test.go
@@ -15,5 +15,4 @@ func Test(t *testing.T) {
 	require.NoError(t, err)
 	stdout := cleanup()
 	require.Contains(t, stdout, "version=\"dev\"")
-
 }

--- a/go/cmd/pathwar/util.go
+++ b/go/cmd/pathwar/util.go
@@ -125,7 +125,7 @@ func httpClientFromEnv(ctx context.Context) (*pwapi.HTTPClient, error) {
 	ssoOpts.TokenFile = filepath.Join(dir, file)
 
 	if _, err := os.Stat(ssoOpts.TokenFile); err != nil {
-		err := os.MkdirAll(dir, 0755)
+		err := os.MkdirAll(dir, 0o755)
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +147,7 @@ func httpClientFromEnv(ctx context.Context) (*pwapi.HTTPClient, error) {
 			return nil, err
 		}
 
-		if err := ioutil.WriteFile(ssoOpts.TokenFile, jsonText, 0777); err != nil {
+		if err := ioutil.WriteFile(ssoOpts.TokenFile, jsonText, 0o777); err != nil {
 			return nil, err
 		}
 	}

--- a/go/cmd/pwinit/main.go
+++ b/go/cmd/pwinit/main.go
@@ -41,7 +41,7 @@ func main() {
 				if u.FileExists("/pwinit/on-init") {
 					log.Print("starting on-init hook")
 					// prepare the challenge
-					err := os.Chmod("/pwinit/on-init", 0555)
+					err := os.Chmod("/pwinit/on-init", 0o555)
 					if err != nil {
 						return errcode.ErrExecuteOnInitHook.Wrap(err)
 					}

--- a/go/internal/randstring/randstring.go
+++ b/go/internal/randstring/randstring.go
@@ -5,6 +5,7 @@ import "math/rand"
 // from https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
 const (
 	letterIdxBits = 6                    // 6 bits to represent a letter index
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits

--- a/go/internal/tools/tools.go
+++ b/go/internal/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // Package tools ensures that `go mod` can detect some required dependencies.

--- a/go/pkg/errcode/error_test.go
+++ b/go/pkg/errcode/error_test.go
@@ -21,7 +21,7 @@ func TestError(t *testing.T) {
 		errStdHello  = fmt.Errorf("hello")
 		errCodeUndef = ErrCode(65530) // simulate a client receiving an error generated from a more recent API
 	)
-	var tests = []struct {
+	tests := []struct {
 		name              string
 		input             error
 		expectedString    string

--- a/go/pkg/pwagent/nginx.go
+++ b/go/pkg/pwagent/nginx.go
@@ -241,7 +241,7 @@ func buildNginxConfigTar(config *nginxConfig, logger *zap.Logger) (*bytes.Buffer
 	tw := tar.NewWriter(&buf)
 	err = tw.WriteHeader(&tar.Header{
 		Name: "nginx.conf",
-		Mode: 0755,
+		Mode: 0o755,
 		Size: int64(len(configBytes)),
 	})
 	if err != nil {

--- a/go/pkg/pwapi/activity_test.go
+++ b/go/pkg/pwapi/activity_test.go
@@ -208,5 +208,4 @@ func TestActivity(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, sess.User.ActiveTeamMember.Team.Cash, int64(0))
 	}
-
 }

--- a/go/pkg/pwapi/api_admin-testing-season-user-add.go
+++ b/go/pkg/pwapi/api_admin-testing-season-user-add.go
@@ -45,7 +45,8 @@ func (svc *service) AdminTestingSeasonUserAdd(ctx context.Context, in *AdminTest
 		Where(pwdb.TeamMember{UserID: userID}).
 		Where(&pwdb.Team{
 			SeasonID:       testingSeasonID,
-			DeletionStatus: pwdb.DeletionStatus_Active}).
+			DeletionStatus: pwdb.DeletionStatus_Active,
+		}).
 		Count(&seasonMemberShipCount).
 		Error
 	if err != nil || seasonMemberShipCount != 0 {

--- a/go/pkg/pwapi/api_agent-list-instances_test.go
+++ b/go/pkg/pwapi/api_agent-list-instances_test.go
@@ -14,7 +14,7 @@ func TestService_AgentListInstances(t *testing.T) {
 	defer cleanup()
 	ctx := testingSetContextToken(context.Background(), t)
 
-	var tests = []struct {
+	tests := []struct {
 		name        string
 		input       *AgentListInstances_Input
 		expectedErr error

--- a/go/pkg/pwapi/api_agent-register_test.go
+++ b/go/pkg/pwapi/api_agent-register_test.go
@@ -16,7 +16,7 @@ func TestService_AgentRegister(t *testing.T) {
 		defer cleanup()
 		ctx := testingSetContextToken(context.Background(), t)
 
-		var tests = []struct {
+		tests := []struct {
 			name        string
 			input       *AgentRegister_Input
 			expectedErr error

--- a/go/pkg/pwapi/api_challenge-get_test.go
+++ b/go/pkg/pwapi/api_challenge-get_test.go
@@ -21,7 +21,7 @@ func TestService_ChallengeGet(t *testing.T) {
 		challenges[challenge.Name] = challenge.ID
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name                  string
 		input                 *ChallengeGet_Input
 		expectedErr           error

--- a/go/pkg/pwapi/api_challenge-subscription-validate.go
+++ b/go/pkg/pwapi/api_challenge-subscription-validate.go
@@ -180,6 +180,15 @@ func (svc *service) ChallengeSubscriptionValidate(ctx context.Context, in *Chall
 			return err
 		}
 
+		// update team score
+		err = tx.Model(&pwdb.Team{}).
+			Where("id = ?", subscription.TeamID).
+			UpdateColumn("score", gorm.Expr("score + ?", subscription.SeasonChallenge.Flavor.ValidationReward)).
+			Error
+		if err != nil {
+			return err
+		}
+
 		activity := pwdb.Activity{
 			Kind:                    pwdb.Activity_ChallengeSubscriptionValidate,
 			AuthorID:                userID,

--- a/go/pkg/pwapi/api_challenge-subscription-validate.go
+++ b/go/pkg/pwapi/api_challenge-subscription-validate.go
@@ -182,7 +182,7 @@ func (svc *service) ChallengeSubscriptionValidate(ctx context.Context, in *Chall
 
 		// update team score
 		err = tx.Model(&pwdb.Team{}).
-			Where("id = ?", subscription.TeamID).
+			Where(pwdb.Team{ID: subscription.TeamID}).
 			UpdateColumn("score", gorm.Expr("score + ?", subscription.SeasonChallenge.Flavor.ValidationReward)).
 			Error
 		if err != nil {

--- a/go/pkg/pwapi/api_challenge-subscription-validate_test.go
+++ b/go/pkg/pwapi/api_challenge-subscription-validate_test.go
@@ -51,16 +51,17 @@ func TestService_ChallengeSubscriptionValidate(t *testing.T) {
 		expectedChallengeSubscriptionID int64
 		expectedValidations             int
 		expectedCash                    int64
+		expectedScore                   int64
 	}{
-		{"nil", nil, errcode.ErrMissingInput, "", 0, 0, 0},
-		{"empty", &ChallengeSubscriptionValidate_Input{}, errcode.ErrMissingInput, "", 0, 0, 0},
-		{"invalid challenge subscription", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: 42, Passphrases: []string{"secret"}, Comment: "explanation"}, errcode.ErrGetChallengeSubscription, "", 0, 0, 0},
-		{"challenge with no instance", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription1.ChallengeSubscription.ID, Passphrases: []string{"secret"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeInactiveValidation, "test", 0, 0, 0},
-		{"3/4 valid", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "b", "c"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeIncompleteValidation, "", 0, 0, 0},
-		{"too many", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "b", "c", "d", "e"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeIncompleteValidation, "", 0, 0, 0},
-		{"bad passphrases", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"e", "f", "g", "h"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeIncompleteValidation, "", 0, 0, 0},
-		{"one good passphrase", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "f", "g", "h"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeIncompleteValidation, "", 0, 0, 0},
-		{"valid", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "b", "c", "d"}, Comment: "ultra cool explanation"}, nil, "[0,1,2,3]", subscription2.ChallengeSubscription.ID, 1, 47},
+		{"nil", nil, errcode.ErrMissingInput, "", 0, 0, 0, 0},
+		{"empty", &ChallengeSubscriptionValidate_Input{}, errcode.ErrMissingInput, "", 0, 0, 0, 0},
+		{"invalid challenge subscription", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: 42, Passphrases: []string{"secret"}, Comment: "explanation"}, errcode.ErrGetChallengeSubscription, "", 0, 0, 0, 0},
+		{"challenge with no instance", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription1.ChallengeSubscription.ID, Passphrases: []string{"secret"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeInactiveValidation, "test", 0, 0, 0, 0},
+		{"3/4 valid", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "b", "c"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeIncompleteValidation, "", 0, 0, 0, 0},
+		{"too many", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "b", "c", "d", "e"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeIncompleteValidation, "", 0, 0, 0, 0},
+		{"bad passphrases", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"e", "f", "g", "h"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeIncompleteValidation, "", 0, 0, 0, 0},
+		{"one good passphrase", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "f", "g", "h"}, Comment: "ultra cool explanation"}, errcode.ErrChallengeIncompleteValidation, "", 0, 0, 0, 0},
+		{"valid", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "b", "c", "d"}, Comment: "ultra cool explanation"}, nil, "[0,1,2,3]", subscription2.ChallengeSubscription.ID, 1, 47, 10},
 		// {"revalid", &ChallengeSubscriptionValidate_Input{ChallengeSubscriptionID: subscription2.ChallengeSubscription.ID, Passphrases: []string{"a", "b", "c", "d"}, Comment: "ultra cool explanation"}, nil, "test", 1},
 		// FIXME: new validation
 	}
@@ -85,6 +86,7 @@ func TestService_ChallengeSubscriptionValidate(t *testing.T) {
 		assert.Equalf(t, test.input.ChallengeSubscriptionID, ret.ChallengeValidation.ChallengeSubscription.ID, test.name)
 		assert.NotEmptyf(t, ret.ChallengeValidation.ChallengeSubscription.Validations, test.name)
 		assert.Equal(t, ret.ChallengeValidation.ChallengeSubscription.Team.Cash, test.expectedCash, test.name)
+		assert.Equal(t, ret.ChallengeValidation.ChallengeSubscription.Team.Score, test.expectedScore, test.name)
 
 		{
 			challenge, err := svc.SeasonChallengeGet(ctx, &SeasonChallengeGet_Input{SeasonChallengeID: ret.ChallengeValidation.ChallengeSubscription.SeasonChallenge.ID})

--- a/go/pkg/pwapi/api_challenge-subscription-validate_test.go
+++ b/go/pkg/pwapi/api_challenge-subscription-validate_test.go
@@ -43,7 +43,7 @@ func TestService_ChallengeSubscriptionValidate(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var tests = []struct {
+	tests := []struct {
 		name                            string
 		input                           *ChallengeSubscriptionValidate_Input
 		expectedErr                     error

--- a/go/pkg/pwapi/api_coupon-validate_test.go
+++ b/go/pkg/pwapi/api_coupon-validate_test.go
@@ -22,7 +22,7 @@ func TestEngine_CouponValidate(t *testing.T) {
 	assert.NoError(t, err)
 	activeTeam := session.User.ActiveTeamMember.Team
 
-	var tests = []struct {
+	tests := []struct {
 		name         string
 		input        *CouponValidate_Input
 		expectedCash int64

--- a/go/pkg/pwapi/api_season-challenge-buy_test.go
+++ b/go/pkg/pwapi/api_season-challenge-buy_test.go
@@ -36,7 +36,7 @@ func TestService_ChallengeBuy(t *testing.T) {
 		}
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name        string
 		input       *SeasonChallengeBuy_Input
 		expectedErr error

--- a/go/pkg/pwapi/api_season-challenge-get_test.go
+++ b/go/pkg/pwapi/api_season-challenge-get_test.go
@@ -26,7 +26,7 @@ func TestService_SeasonChallengeGet(t *testing.T) {
 		seasonChallenges[key] = seasonChallenge.ID
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name                  string
 		input                 *SeasonChallengeGet_Input
 		expectedErr           error

--- a/go/pkg/pwapi/api_season-challenge-list_test.go
+++ b/go/pkg/pwapi/api_season-challenge-list_test.go
@@ -24,7 +24,7 @@ func TestService_SeasonChallengeList(t *testing.T) {
 		seasons[season.Name] = season.ID
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name          string
 		input         *SeasonChallengeList_Input
 		expectedErr   error

--- a/go/pkg/pwapi/api_team-accept-invite.go
+++ b/go/pkg/pwapi/api_team-accept-invite.go
@@ -45,7 +45,8 @@ func (svc *service) TeamAcceptInvite(ctx context.Context, in *TeamAcceptInvite_I
 		Where(pwdb.TeamMember{UserID: userID}).
 		Where(&pwdb.Team{
 			SeasonID:       teamInvite.Team.SeasonID,
-			DeletionStatus: pwdb.DeletionStatus_Active}).
+			DeletionStatus: pwdb.DeletionStatus_Active,
+		}).
 		Count(&seasonMemberShipCount).
 		Error
 	if err != nil || seasonMemberShipCount != 0 {

--- a/go/pkg/pwapi/api_team-accept-invite_test.go
+++ b/go/pkg/pwapi/api_team-accept-invite_test.go
@@ -66,7 +66,7 @@ func TestService_TeamAcceptInvite(t *testing.T) {
 	require.NoError(t, err)
 	teamInvite2 := ret2.TeamInvite
 
-	var tests = []struct {
+	tests := []struct {
 		name        string
 		input       *TeamAcceptInvite_Input
 		expectedErr error

--- a/go/pkg/pwapi/api_team-create.go
+++ b/go/pkg/pwapi/api_team-create.go
@@ -60,7 +60,8 @@ func (svc *service) TeamCreate(ctx context.Context, in *TeamCreate_Input) (*Team
 		Where(pwdb.TeamMember{UserID: userID}).
 		Where(&pwdb.Team{
 			SeasonID:       seasonID,
-			DeletionStatus: pwdb.DeletionStatus_Active}).
+			DeletionStatus: pwdb.DeletionStatus_Active,
+		}).
 		Count(&seasonMemberShipCount).
 		Error
 	if err != nil || seasonMemberShipCount != 0 {
@@ -156,6 +157,11 @@ func (svc *service) TeamCreate(ctx context.Context, in *TeamCreate_Input) (*Team
 		SeasonID:       seasonID,
 		OrganizationID: organizationID,
 		DeletionStatus: pwdb.DeletionStatus_Active,
+		Score:          0,
+		GoldMedals:     0,
+		SilverMedals:   0,
+		BronzeMedals:   0,
+		NbAchievements: 0,
 		Members: []*pwdb.TeamMember{
 			{
 				UserID: userID,

--- a/go/pkg/pwapi/api_team-create_test.go
+++ b/go/pkg/pwapi/api_team-create_test.go
@@ -53,7 +53,7 @@ func TestService_TeamCreate(t *testing.T) {
 		seasonMap[item.Season.Name] = item
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name        string
 		input       *TeamCreate_Input
 		expectedErr error

--- a/go/pkg/pwapi/api_team-get_test.go
+++ b/go/pkg/pwapi/api_team-get_test.go
@@ -23,7 +23,7 @@ func TestService_TeamGet(t *testing.T) {
 		teams[key] = team.ID
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name                     string
 		input                    *TeamGet_Input
 		expectedErr              error

--- a/go/pkg/pwapi/api_team-list.go
+++ b/go/pkg/pwapi/api_team-list.go
@@ -2,7 +2,6 @@ package pwapi
 
 import (
 	"context"
-	"math/rand"
 
 	"pathwar.land/pathwar/v2/go/pkg/errcode"
 	"pathwar.land/pathwar/v2/go/pkg/pwdb"
@@ -34,16 +33,6 @@ func (svc *service) TeamList(ctx context.Context, in *TeamList_Input) (*TeamList
 		Error
 	if err != nil {
 		return nil, errcode.ErrGetTeams.Wrap(err)
-	}
-
-	// add fake data
-	// FIXME: use real data instead
-	for _, team := range ret.Items {
-		team.GoldMedals = int64(rand.Intn(3))
-		team.SilverMedals = int64(rand.Intn(3))
-		team.BronzeMedals = int64(rand.Intn(4))
-		team.Score = int64(rand.Intn(100))
-		team.NbAchievements = int64(rand.Intn(10))
 	}
 
 	return &ret, nil

--- a/go/pkg/pwapi/api_team-list_test.go
+++ b/go/pkg/pwapi/api_team-list_test.go
@@ -21,7 +21,7 @@ func TestService_TeamList(t *testing.T) {
 		seasons[season.Name] = season.ID
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name                  string
 		input                 *TeamList_Input
 		expectedErr           error

--- a/go/pkg/pwapi/api_team-send-invite.go
+++ b/go/pkg/pwapi/api_team-send-invite.go
@@ -63,7 +63,8 @@ func (svc *service) TeamSendInvite(ctx context.Context, in *TeamSendInvite_Input
 		Where(pwdb.TeamMember{UserID: invitedUserID}).
 		Where(&pwdb.Team{
 			SeasonID:       team.SeasonID,
-			DeletionStatus: pwdb.DeletionStatus_Active}).
+			DeletionStatus: pwdb.DeletionStatus_Active,
+		}).
 		Count(&seasonMemberShipCount).
 		Error
 	if err != nil || seasonMemberShipCount != 0 {

--- a/go/pkg/pwapi/api_team-send-invite_test.go
+++ b/go/pkg/pwapi/api_team-send-invite_test.go
@@ -63,7 +63,7 @@ func TestService_TeamSendInvite(t *testing.T) {
 	require.NoError(t, err)
 	team4 := ret.Team
 
-	var tests = []struct {
+	tests := []struct {
 		name        string
 		input       *TeamSendInvite_Input
 		expectedErr error

--- a/go/pkg/pwapi/api_user-set-preferences_test.go
+++ b/go/pkg/pwapi/api_user-set-preferences_test.go
@@ -23,7 +23,7 @@ func TestService_UserSetPreferences(t *testing.T) {
 		seasons[season.Season.Name] = season.Season.ID
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		name                 string
 		input                *UserSetPreferences_Input
 		expectedErr          error

--- a/go/pkg/pwapi/helpers.go
+++ b/go/pkg/pwapi/helpers.go
@@ -27,7 +27,6 @@ func seasonFromSeasonChallengeID(db *gorm.DB, seasonChallengeID int64) (*pwdb.Se
 		Preload("Season").
 		First(&seasonChallenge, seasonChallengeID).
 		Error
-
 	if err != nil {
 		return nil, err
 	}

--- a/go/pkg/pwapi/server.go
+++ b/go/pkg/pwapi/server.go
@@ -278,7 +278,7 @@ func httpServer(ctx context.Context, serverListenerAddr string, opts ServerOpts)
 	var gwmux http.Handler = runtimeMux
 	dialOpts := []grpc.DialOption{grpc.WithInsecure()}
 	if opts.Tracer != nil {
-		var grpcGatewayTag = opentracing.Tag{Key: string(ext.Component), Value: "grpc-gateway"}
+		grpcGatewayTag := opentracing.Tag{Key: string(ext.Component), Value: "grpc-gateway"}
 		tracingWrapper := func(h http.Handler) http.Handler {
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				parentSpanContext, err := opts.Tracer.Extract(

--- a/go/pkg/pwapi/tracing.go
+++ b/go/pkg/pwapi/tracing.go
@@ -6,24 +6,22 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 )
 
-var (
-	// trace header to propagate.
-	traceHeaders = []string{
-		"x-ot-span-context",
-		"x-request-id",
+// trace header to propagate.
+var traceHeaders = []string{
+	"x-ot-span-context",
+	"x-request-id",
 
-		// Zipkin headers
-		"b3",
-		"x-b3-traceid",
-		"x-b3-spanid",
-		"x-b3-parentspanid",
-		"x-b3-sampled",
-		"X-b3-flags",
+	// Zipkin headers
+	"b3",
+	"x-b3-traceid",
+	"x-b3-spanid",
+	"x-b3-parentspanid",
+	"x-b3-sampled",
+	"X-b3-flags",
 
-		// Jaeger header (for native client)
-		"uber-trace-id",
-	}
-)
+	// Jaeger header (for native client)
+	"uber-trace-id",
+}
 
 func incomingHeaderMatcherFunc(key string) (string, bool) {
 	k := strings.ToLower(key)

--- a/go/pkg/pwcompose/composebin.go
+++ b/go/pkg/pwcompose/composebin.go
@@ -8,7 +8,7 @@ import (
 )
 
 func ComposeBinBytes() ([]byte, error) {
-	var pwinitBox = packr.New("binaries", "../../out")
+	pwinitBox := packr.New("binaries", "../../out")
 	return pwinitBox.Find("docker-compose-dab")
 }
 
@@ -27,7 +27,7 @@ func tmpComposeBin() (*os.File, func(), error) {
 		return nil, nil, err
 	}
 
-	if err := os.Chmod(file.Name(), 0555); err != nil {
+	if err := os.Chmod(file.Name(), 0o555); err != nil {
 		return nil, nil, err
 	}
 

--- a/go/pkg/pwcompose/up.go
+++ b/go/pkg/pwcompose/up.go
@@ -306,7 +306,7 @@ func buildPWInitTar(config pwinit.InitConfig) (*bytes.Buffer, error) {
 	// write pwinit binary into tar file
 	err = tw.WriteHeader(&tar.Header{
 		Name: "/bin/pwinit",
-		Mode: 0755,
+		Mode: 0o755,
 		Size: int64(len(pwInitBuf)),
 	})
 	if err != nil {
@@ -324,7 +324,7 @@ func buildPWInitTar(config pwinit.InitConfig) (*bytes.Buffer, error) {
 	}
 	err = tw.WriteHeader(&tar.Header{
 		Name: "/pwinit/config.json",
-		Mode: 0755,
+		Mode: 0o755,
 		Size: int64(len(pwInitConfigJSON)),
 		// FIXME: chown it to container's default user
 	})

--- a/go/pkg/pwinit/inject.go
+++ b/go/pkg/pwinit/inject.go
@@ -3,6 +3,6 @@ package pwinit
 import "github.com/gobuffalo/packr/v2"
 
 func Binary() ([]byte, error) {
-	var pwinitBox = packr.New("binaries", "../../out")
+	pwinitBox := packr.New("binaries", "../../out")
 	return pwinitBox.Find("pwinit-linux-amd64")
 }


### PR DESCRIPTION
I removed the random return of the score and added the feature that adds points to the player when he finishes a level.

The challenge gives as many points as cash.

I added a test at this level similar to the one for cash

Besides I passed a gofumpt, if it makes trouble I can redo the PR without it.


Signed-off-by: Mikatech <mikael.vallenet@epitech.eu>