### PR TITLE
Fix the broken link to the challenge maintainers wiki

### DIFF
--- a/challenges/README.md
+++ b/challenges/README.md
@@ -1,3 +1,3 @@
 # Challenges
 
-See the [Challenge Maintainers](https://github.com/pathwar/pathwar/wiki/Challenge-Maintainers) page on the Wiki.
+See the [Challenge Maintainers](https://wip-foundation.notion.site/Developers-Contributors-2feb388e94174c328e4369d483ca26ed#185b874f46fc4525b2eb6218fd205730) section of the Developers & Contributors page.


### PR DESCRIPTION
The Github wiki page seems to be deleted. Now the challenge maintainers link goes to the notion page, section challenge maintainers

<!-- Thank you for your contribution ❤️ -->